### PR TITLE
Vnode open/close/destroy structure

### DIFF
--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -72,7 +72,7 @@ typedef struct
 }
 vfs_dirent_t;
 
-static int vnode_destroy(vnode_t *vn);
+int vnode_destroy(vnode_t *vn, int flags);
 
 /**
  * @brief Increment vnode reference count.
@@ -100,7 +100,7 @@ static inline bool vnode_unref(vnode_t *vn)
 {
     if (atomic_fetch_sub_explicit(&vn->refcount, 1, memory_order_acq_rel) == 1)
     {
-        vnode_destroy(vn);
+        vnode_destroy(vn, 0);
         return true;
     }
     return false;
@@ -108,8 +108,9 @@ static inline bool vnode_unref(vnode_t *vn)
 
 struct vnode_ops
 {
-    int (*open)   (vnode_t **vpp, int f, void *cred);
-    int (*close)  (vnode_t *vp, int f, void *cred);
+    int (*open)   (vnode_t *vn, int flags, void *cred);
+    int (*close)  (vnode_t *vp, int flags, void *cred);
+    int (*destroy)(vnode_t *vn, int flags);
     int (*read)   (vnode_t *vn, void *buffer, uint64_t offset, uint64_t count, uint64_t *out_bytes_read);
     int (*write)  (vnode_t *vn, const void *buffer, uint64_t offset, uint64_t count, uint64_t *out_bytes_written);
     int (*lookup) (vnode_t *vn, const char *name, vnode_t **out_vn);

--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -72,6 +72,8 @@ typedef struct
 }
 vfs_dirent_t;
 
+int vfs_destroy(vnode_t *vn);
+
 /**
  * @brief Increment vnode reference count.
  *
@@ -98,8 +100,7 @@ static inline bool vnode_unref(vnode_t *vn)
 {
     if (atomic_fetch_sub_explicit(&vn->refcount, 1, memory_order_acq_rel) == 1)
     {
-        if (vn->ops && vn->ops->destroy)
-            vn->ops->destroy(vn, 0);
+        vfs_destroy(vn);
         return true;
     }
     return false;

--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -72,6 +72,8 @@ typedef struct
 }
 vfs_dirent_t;
 
+static int vnode_destroy(vnode_t *vn);
+
 /**
  * @brief Increment vnode reference count.
  *
@@ -98,7 +100,7 @@ static inline bool vnode_unref(vnode_t *vn)
 {
     if (atomic_fetch_sub_explicit(&vn->refcount, 1, memory_order_acq_rel) == 1)
     {
-        // TODO: run vnode destructor
+        vnode_destroy(vn);
         return true;
     }
     return false;
@@ -106,6 +108,8 @@ static inline bool vnode_unref(vnode_t *vn)
 
 struct vnode_ops
 {
+    int (*open)   (vnode_t **vpp, int f, void *cred);
+    int (*close)  (vnode_t *vp, int f, void *cred);
     int (*read)   (vnode_t *vn, void *buffer, uint64_t offset, uint64_t count, uint64_t *out_bytes_read);
     int (*write)  (vnode_t *vn, const void *buffer, uint64_t offset, uint64_t count, uint64_t *out_bytes_written);
     int (*lookup) (vnode_t *vn, const char *name, vnode_t **out_vn);

--- a/kernel/include/mm/vm.h
+++ b/kernel/include/mm/vm.h
@@ -26,7 +26,6 @@ typedef struct
 {
     uintptr_t start;
     size_t length;
-    int prot;
 
     int prot;
     int flags;

--- a/kernel/source/fs/ramfs.c
+++ b/kernel/source/fs/ramfs.c
@@ -41,6 +41,7 @@ static int read  (vnode_t *self, void *buf, uint64_t offset, uint64_t count, uin
 static int write (vnode_t *self, const void *buf, uint64_t offset, uint64_t count, uint64_t *out);
 static int open  (vnode_t *self, int flags, void *cred);
 static int close (vnode_t *self, int flags, void *cred);
+static int destroy(vnode_t *self, int flags);
 static int lookup(vnode_t *self, const char *name, vnode_t **out);
 static int create(vnode_t *self, const char *name, vnode_type_t t, vnode_t **out);
 static int remove(vnode_t *self, const char *name);
@@ -49,6 +50,7 @@ static int readdir(vnode_t *self, vfs_dirent_t **out_entries, size_t *out_count)
 vnode_ops_t ramfs_node_ops = {
     .open   = open,
     .close  = close,
+    .destroy = destroy,
     .read   = read,
     .write  = write,
     .lookup = lookup,
@@ -143,6 +145,7 @@ static int write(vnode_t *self, const void *buf, uint64_t offset, uint64_t count
         {
             page = (void*)(pm_alloc(0)->addr + HHDM);
             xa_insert(&node->pages, page_idx, page);
+            node->page_count = page_idx + 1;
         }
 
         memcpy((uint8_t *)page + page_off, src + written, to_copy);

--- a/kernel/source/fs/vfs.c
+++ b/kernel/source/fs/vfs.c
@@ -175,19 +175,6 @@ int vfs_ioctl(vnode_t *vn, uint64_t cmd, void *arg)
     return vn->ops->ioctl(vn, cmd, arg);
 }
 
-int vnode_destroy(vnode_t *vn, int flags)
-{
-    if (!vn)
-        return EINVAL;
-
-    // Generic fallback
-    vn->ops = NULL;
-    vn->inode = NULL;
-    vn->size = 0;
-    vn->type = VNON;
-    return EOK;
-}
-
 int vfs_open(vnode_t *vn, int flags, void *cred)
 {
     if (!vn)
@@ -198,7 +185,7 @@ int vfs_open(vnode_t *vn, int flags, void *cred)
     if (vn->ops->open)
         return vn->ops->open(vn, flags, cred);
     
-    return EOK;
+    return ENOTSUP;
 }
 
 int vfs_close(vnode_t *vn, int flags, void *cred)
@@ -211,7 +198,7 @@ int vfs_close(vnode_t *vn, int flags, void *cred)
     if (vn->ops->close)
         return vn->ops->close(vn, flags, cred);
     
-    return EOK;
+    return ENOTSUP;
 }
 
 void vfs_init()

--- a/kernel/source/fs/vfs.c
+++ b/kernel/source/fs/vfs.c
@@ -200,7 +200,16 @@ int vfs_close(vnode_t *vn, int flags, void *cred)
     
     return ENOTSUP;
 }
+int vfs_destroy(vnode_t *vn)
+{
+    if (!vn)
+        return EINVAL;
 
+    if (vn->ops && vn->ops->destroy)
+        return vn->ops->destroy(vn, 0);
+
+    return ENOTSUP;
+}
 void vfs_init()
 {
     vfs_t *ramfs = ramfs_create();

--- a/kernel/source/fs/vfs.c
+++ b/kernel/source/fs/vfs.c
@@ -172,6 +172,41 @@ int vfs_ioctl(vnode_t *vn, uint64_t cmd, void *arg)
     return vn->ops->ioctl(vn, cmd, arg);
 }
 
+static int vnode_destroy(vnode_t *vn)
+{
+    if (!vn)
+        return;
+
+    // Generic fallback
+    vn->ops = NULL;
+    vn->inode = NULL;
+    vn->size = 0;
+    vn->type = VNON;
+    return EOK;
+}
+
+int vfs_open(vnode_t *vn, int flags, void *cred)
+{
+    if (!vn)
+        return EINVAL;
+
+    // TODO: permission checks
+
+    vnode_ref(vn);
+    return EOK;
+}
+
+int vfs_close(vnode_t *vn, int flags, void *cred)
+{
+    if (!vn)
+        return EINVAL;
+
+    // TODO: permission checks
+
+    vnode_unref(vn);
+    return EOK;
+}
+
 void vfs_init()
 {
     vfs_t *ramfs = ramfs_create();


### PR DESCRIPTION
vnode open / close:
FD table and syscall layer do manual ref/unref - should these go through vn_open/vn_close instead?

vnode destroy:
Should each filesystem provide a destroy hook in vnode_ops?